### PR TITLE
Check fakehosts while enforcing bans on JOINs

### DIFF
--- a/Channel/p10/handle_J.php
+++ b/Channel/p10/handle_J.php
@@ -35,7 +35,9 @@
 	$infoline = '';
 	
 	if ($reg) {
-		if (($ban = $reg->getMatchingBan($user->getFullMask()))) {
+		if (($ban = $reg->getMatchingBan($user->getFullMask()))
+				|| ($ban = $reg->getMatchingBan($user->getFullMaskSafe()))
+				|| ($ban = $reg->getMatchingBan($user->getFullIpMask()))) {
 			$reason = $ban->getReason();
 			if (empty($reason))
 				$reason = 'Banned';


### PR DESCRIPTION
```
    Check fakehosts while enforcing bans on JOINs
    
    Previously we were only checking for inactive channel bans that matched a
    user's real hostname. Now, we check the real hostmask, real IP mask, and the
    fake/hidden hostmask, if the user has the appropriate umode enabled.
    
    Closes: #8
```